### PR TITLE
feat: add template-whoami to catalog

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: flux-system
 
 resources:
   - templates/template-dns-record.yaml
+  - templates/template-whoami.yaml

--- a/templates/template-whoami.yaml
+++ b/templates/template-whoami.yaml
@@ -1,0 +1,28 @@
+# WhoAmI App Template
+# Provides XRD and Compositions for WhoAmI demo application deployment
+# Supports both direct Kubernetes deployment and GitOps workflows
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: template-whoami
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  url: https://github.com/open-service-portal/template-whoami
+  ref:
+    branch: main
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: template-whoami
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: template-whoami
+  path: "./"
+  prune: true
+  targetNamespace: crossplane-system


### PR DESCRIPTION
## Summary

This PR adds the `template-whoami` Crossplane template to the catalog for automatic Flux synchronization.

## What's Added

- **template-whoami**: A WhoAmIApp XR template that provides:
  - Dual deployment modes: Direct (default) and GitOps
  - Automatic domain detection from cluster dns-config
  - Dynamic subdomain creation based on app name
  - Zero configuration needed - works out of the box

## Template Features

- **Direct Mode (Default)**: Deploys resources immediately to Kubernetes
- **GitOps Mode**: Creates GitHub repository with manifests for Flux deployment
- **Auto Domain Detection**: Uses cluster's dns-config zone or defaults to localhost
- **Restaurant Analogy**: Uses familiar concepts (menu/recipe) to explain Crossplane concepts

## Testing

The template has been:
- Pushed to https://github.com/open-service-portal/template-whoami
- Configured with both deployment compositions
- Set with direct mode as default

## Next Steps

Once merged, Flux will:
1. Create GitRepository source for template-whoami
2. Apply the XRD and Compositions to the cluster
3. Make WhoAmIApp available for developers to use