### PR TITLE
feat: add template-cloudflare-dnsrecord to catalog

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: flux-system
 resources:
   - templates/template-dns-record.yaml
   - templates/template-whoami.yaml
+  - templates/template-cloudflare-dnsrecord.yaml

--- a/templates/template-cloudflare-dnsrecord.yaml
+++ b/templates/template-cloudflare-dnsrecord.yaml
@@ -1,0 +1,27 @@
+# Cloudflare DNS Record Template
+# Provides real DNS record management in Cloudflare
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: template-cloudflare-dnsrecord
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  url: https://github.com/open-service-portal/template-cloudflare-dnsrecord
+  ref:
+    branch: main
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: template-cloudflare-dnsrecord
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: template-cloudflare-dnsrecord
+  path: "./"
+  prune: true
+  targetNamespace: crossplane-system


### PR DESCRIPTION
## Summary

Adds the CloudflareDNSRecord template to the catalog for real DNS management.

## What's Added

- **template-cloudflare-dnsrecord**: Real Cloudflare DNS record management
  - Creates actual DNS records in Cloudflare 
  - Supports A, AAAA, CNAME, TXT, MX records
  - Cloudflare proxy (orange cloud) support
  - Requires Cloudflare API token and Zone ID configuration

## Prerequisites

1. Install provider-cloudflare
2. Configure Cloudflare API token
3. Set Zone ID in cloudflare-config

## Testing

Once merged, Flux will sync the template and make CloudflareDNSRecord available for creating real DNS records.