### PR TITLE
feat: add WhoAmI Service template to catalog

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - templates/template-dns-record.yaml
   - templates/template-whoami.yaml
   - templates/template-cloudflare-dnsrecord.yaml
+  - templates/template-whoami-service.yaml

--- a/templates/template-whoami-service.yaml
+++ b/templates/template-whoami-service.yaml
@@ -1,0 +1,25 @@
+# WhoAmI Service Template Registration
+# Purpose: Register the composition-of-compositions template in the catalog
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: template-whoami-service
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: template-whoami-service
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: template-whoami-service
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: https://github.com/open-service-portal/template-whoami-service
+  ref:
+    branch: main


### PR DESCRIPTION
## Summary
Adds the new WhoAmI Service template to the Flux catalog for automatic deployment.

## Details
The WhoAmI Service template demonstrates the composition-of-compositions pattern by orchestrating:
- **WhoAmI App** (from `template-whoami`) - Creates Deployment, Service, Ingress
- **CloudflareDNSRecord** (from `template-cloudflare-dnsrecord`) - Creates DNS A record

## Benefits
- Single resource creates complete publicly accessible service
- Automatic IP detection from Ingress
- No code duplication - fully reuses existing templates
- Establishes pattern for future composition-of-compositions

## Template Repository
https://github.com/open-service-portal/template-whoami-service

## Related
- Implements open-service-portal/portal-workspace#48
- Uses existing templates as building blocks
- Follows Crossplane v2 best practices

## Testing
```bash
# Apply via Flux
kubectl apply -k catalog/

# Or directly
kubectl apply -k https://github.com/open-service-portal/template-whoami-service

# Create example service
kubectl apply -f - <<YAML
apiVersion: demo.openportal.dev/v1alpha1
kind: WhoAmIService
metadata:
  name: test-service
spec:
  name: test
YAML
```