### PR TITLE
feat: add namespace template to catalog

### DIFF
--- a/templates/template-namespace.yaml
+++ b/templates/template-namespace.yaml
@@ -1,8 +1,28 @@
-# Namespace Template Registration
-# Purpose: Kubernetes namespace management with quotas, policies, and RBAC
-# Restaurant Analogy: "Table reservation system" - manages dedicated spaces
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - https://github.com/open-service-portal/template-namespace/xrd.yaml
-  - https://github.com/open-service-portal/template-namespace/composition.yaml
+---
+# Namespace Configuration Package
+# Provides XRD and Composition for Kubernetes namespace management
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: configuration-namespace
+  namespace: crossplane-system
+spec:
+  package: ghcr.io/open-service-portal/configuration-namespace:v1alpha1
+
+  # Package pull policy
+  # IfNotPresent: Only download if not in cache (recommended for production)
+  # Always: Check for updates on reconciliation (useful for development)
+  packagePullPolicy: IfNotPresent
+
+  # Revision activation policy
+  # Automatic: New revisions become active immediately (good for single-tenant)
+  # Manual: Requires manual activation (safer for multi-tenant production)
+  revisionActivationPolicy: Automatic
+
+  # Number of inactive revisions to keep
+  # Useful for rollback scenarios
+  revisionHistoryLimit: 3
+
+  # Skip dependency resolution
+  # Set to true if providers are pre-installed in the cluster
+  skipDependencyResolution: true


### PR DESCRIPTION
## Summary
Add template-namespace to the catalog for Kubernetes namespace provisioning.

## Features
The namespace template provides:
- ✅ Namespace creation with custom labels and annotations
- ✅ Optional resource quotas for cost control  
- ✅ Optional network policies for security isolation
- ✅ Team-based RBAC configuration
- ✅ Default service account setup

## Changes
- Add `template-namespace.yaml` configuration entry
- Update `kustomization.yaml` to include new template
- Document namespace template in README

## Package Details
- **Package**: `ghcr.io/open-service-portal/configuration-namespace:v1alpha1`
- **Kind**: `platform.io/v1alpha1/Namespace` (no X prefix, following our convention)
- **Scope**: Namespaced XRs (Crossplane v2 style)

## Usage Example
```yaml
apiVersion: platform.io/v1alpha1
kind: Namespace
metadata:
  name: my-namespace
  namespace: default
spec:
  name: my-namespace
  team: my-team
  environment: dev
  quotas:
    enabled: true
    limits:
      cpu: "20"
      memory: "32Gi"
```

## Related
- Template repository: https://github.com/open-service-portal/template-namespace
- Packaging PR: https://github.com/open-service-portal/template-namespace/pull/1