### PR TITLE
feat: update CloudflareDNSRecord template to v2.0.0

### DIFF
--- a/templates/template-cloudflare-dnsrecord.yaml
+++ b/templates/template-cloudflare-dnsrecord.yaml
@@ -1,5 +1,6 @@
 # Cloudflare DNS Record Template
-# Provides real DNS record management in Cloudflare
+# Provides real DNS record management via External-DNS
+# Breaking Change in v2.0.0: Migrated from provider-cloudflare to External-DNS
 # Deployed via OCI Configuration package from GitHub Container Registry
 ---
 apiVersion: pkg.crossplane.io/v1
@@ -8,11 +9,12 @@ metadata:
   name: configuration-cloudflare-dnsrecord
   namespace: crossplane-system
   annotations:
-    meta.crossplane.io/description: "Manage real DNS records in Cloudflare"
+    meta.crossplane.io/description: "Manage DNS records via External-DNS with namespace isolation"
     meta.crossplane.io/maintainer: "Open Service Portal Team"
     meta.crossplane.io/source: "github.com/open-service-portal/template-cloudflare-dnsrecord"
+    meta.crossplane.io/breaking-change: "v2.0.0 - Requires External-DNS instead of provider-cloudflare"
 spec:
-  package: ghcr.io/open-service-portal/configuration-cloudflare-dnsrecord:v1.0.1
+  package: ghcr.io/open-service-portal/configuration-cloudflare-dnsrecord:v2.0.0
   
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
## Summary
Updates the CloudflareDNSRecord template to v2.0.0, which migrates from provider-cloudflare to External-DNS integration.

## ⚠️ Breaking Change
This is a **major version update** with breaking changes. The template now requires External-DNS instead of provider-cloudflare.

## Changes
- Updated package version from `v1.0.1` to `v2.0.0`
- Updated description to reflect External-DNS integration
- Added breaking change annotation for visibility
- Updated comments to explain the architectural change

## Migration Impact
When Flux syncs this change:
1. The new Composition will be deployed
2. Existing CloudflareDNSRecord XRs will reconcile
3. DNSEndpoint resources will be created instead of provider resources
4. External-DNS will handle the actual DNS updates

## Prerequisites
Before this can be deployed, ensure:
- ✅ External-DNS is installed with custom API group (`externaldns.openportal.dev`)
- ✅ External-DNS is configured with Cloudflare credentials
- ✅ DNSEndpoint CRD is available in the cluster

## Benefits
- 🔒 **Namespace isolation** - Teams can manage DNS in their own namespaces
- 🚀 **No cluster-scoped resources** - Resolves the limitation from portal-workspace#70
- 🎯 **Better multi-tenancy** - Each team's DNS records are isolated
- 🔧 **Simplified provider management** - External-DNS handles provider interaction

## Related
- Template Release: [v2.0.0](https://github.com/open-service-portal/template-cloudflare-dnsrecord/releases/tag/v2.0.0)
- Template PR: open-service-portal/template-cloudflare-dnsrecord#5
- Issue: open-service-portal/portal-workspace#70

## Testing
The updated template has been tested locally:
- [x] Composition applies successfully
- [x] XRs create DNSEndpoint resources
- [x] DNSEndpoints are created in the correct namespace
- [x] External-DNS processes the DNSEndpoints

## Rollback Plan
If issues occur, revert this PR to restore v1.0.1 which uses provider-cloudflare.