### PR TITLE
chore: update WhoAmI templates to v1.0.3

### DIFF
--- a/templates/template-whoami-service.yaml
+++ b/templates/template-whoami-service.yaml
@@ -1,33 +1,14 @@
-# WhoAmI Service Template  
-# Composition of compositions - combines WhoAmI app with DNS configuration
-# Deployed via OCI Configuration package from GitHub Container Registry
 ---
+# WhoAmI Service Configuration Package  
+# Provides composite service with app + DNS
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
   name: configuration-whoami-service
   namespace: crossplane-system
-  annotations:
-    meta.crossplane.io/description: "Complete service with WhoAmI app deployment and DNS configuration"
-    meta.crossplane.io/maintainer: "Open Service Portal Team"
-    meta.crossplane.io/source: "github.com/open-service-portal/template-whoami-service"
 spec:
-  package: ghcr.io/open-service-portal/configuration-whoami-service:v1.0.2
-  
-  # Package pull policy
-  # IfNotPresent: Only download if not in cache (recommended for production)
-  # Always: Check for updates on reconciliation (useful for development)
+  package: ghcr.io/open-service-portal/configuration-whoami-service:v1.0.3
   packagePullPolicy: IfNotPresent
-  
-  # Revision activation policy
-  # Automatic: New revisions become active immediately (good for single-tenant)
-  # Manual: Requires manual activation (safer for multi-tenant production)
   revisionActivationPolicy: Automatic
-  
-  # Number of inactive revisions to keep
-  # Useful for rollback scenarios
   revisionHistoryLimit: 3
-  
-  # Skip dependency resolution
-  # Set to true since providers are pre-installed in the cluster
   skipDependencyResolution: true

--- a/templates/template-whoami.yaml
+++ b/templates/template-whoami.yaml
@@ -1,33 +1,14 @@
-# WhoAmI Application Template
-# Provides a simple demo application with automatic domain configuration
-# Deployed via OCI Configuration package from GitHub Container Registry
 ---
+# WhoAmI Configuration Package
+# Provides XRD and Composition for demo application deployment
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
   name: configuration-whoami
   namespace: crossplane-system
-  annotations:
-    meta.crossplane.io/description: "Simple demo application with automatic domain configuration"
-    meta.crossplane.io/maintainer: "Open Service Portal Team"
-    meta.crossplane.io/source: "github.com/open-service-portal/template-whoami"
 spec:
-  package: ghcr.io/open-service-portal/configuration-whoami:v1.0.2
-  
-  # Package pull policy
-  # IfNotPresent: Only download if not in cache (recommended for production)
-  # Always: Check for updates on reconciliation (useful for development)
+  package: ghcr.io/open-service-portal/configuration-whoami:v1.0.3
   packagePullPolicy: IfNotPresent
-  
-  # Revision activation policy
-  # Automatic: New revisions become active immediately (good for single-tenant)
-  # Manual: Requires manual activation (safer for multi-tenant production)
   revisionActivationPolicy: Automatic
-  
-  # Number of inactive revisions to keep
-  # Useful for rollback scenarios
   revisionHistoryLimit: 3
-  
-  # Skip dependency resolution
-  # Set to true since providers are pre-installed in the cluster
   skipDependencyResolution: true


### PR DESCRIPTION
## Summary
Update WhoAmI templates to their latest v1.0.3 releases.

## Updated Templates
- **template-whoami**: `v1.0.3` - Demo application deployment
- **template-whoami-service**: `v1.0.3` - Composite service (app + DNS)

## Changes in v1.0.3
Both templates were updated with:
- Added `openportal.dev/version: "dev"` label for version tracking
- Fixed GitHub Actions workflow to only use yq on XRD files (prevents YAML corruption)
- Follows new template standards for version management

## Package References
- `ghcr.io/open-service-portal/configuration-whoami:v1.0.3`
- `ghcr.io/open-service-portal/configuration-whoami-service:v1.0.3`

These releases were triggered by tags but the templates don't have automated catalog PR creation yet (will be added in future updates).