### PR TITLE
chore: update all templates to latest versions

### DIFF
--- a/templates/template-cloudflare-dnsrecord.yaml
+++ b/templates/template-cloudflare-dnsrecord.yaml
@@ -14,7 +14,7 @@ metadata:
     meta.crossplane.io/source: "github.com/open-service-portal/template-cloudflare-dnsrecord"
     meta.crossplane.io/breaking-change: "v2.0.0 - Requires External-DNS instead of provider-cloudflare"
 spec:
-  package: ghcr.io/open-service-portal/configuration-cloudflare-dnsrecord:v2.0.0
+  package: ghcr.io/open-service-portal/configuration-cloudflare-dnsrecord:v2.0.1
   
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)

--- a/templates/template-dns-record.yaml
+++ b/templates/template-dns-record.yaml
@@ -7,7 +7,7 @@ metadata:
   name: configuration-dns-record
   namespace: crossplane-system
 spec:
-  package: ghcr.io/open-service-portal/configuration-dns-record:v1.0.5
+  package: ghcr.io/open-service-portal/configuration-dns-record:v1.0.6
 
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
## Summary
Update all Crossplane templates to their latest released versions in the catalog.

## Version Updates
| Template | Previous | New | Changes |
|----------|----------|-----|---------|
| template-cloudflare-dnsrecord | v2.0.0 | **v2.0.1** | External-DNS migration, workflow fixes |
| template-dns-record | v1.0.5 | **v1.0.6** | Modernized workflow with reusable components |
| template-namespace | v2.0.2 | v2.0.2 | Already updated via automation |
| template-whoami | v1.0.3 | v1.0.3 | Already up to date |
| template-whoami-service | v1.0.3 | v1.0.3 | Already up to date |

## Key Improvements in New Versions

### All Templates
- ✅ Added `openportal.dev/version: "dev"` label placeholder in XRDs
- ✅ Fixed GitHub Actions workflows to only use yq on XRDs (prevents YAML corruption)
- ✅ Full compliance with updated template standards

### template-cloudflare-dnsrecord v2.0.1
- Migrated from provider-cloudflare to External-DNS pattern
- Removed deprecated status.provider field
- Fixed version label handling

### template-dns-record v1.0.6  
- Adopted reusable catalog update workflow
- Split workflow into modular jobs (vars, build, catalog, release)
- Dynamic package naming using repository name
- Enhanced release notes with structure

## Testing
All releases have been successfully built and pushed to ghcr.io. Flux will automatically reconcile these changes once merged.

## Related PRs
- open-service-portal/portal-workspace#77 - Template standards documentation
- open-service-portal/catalog#17 - Reusable workflow implementation