### PR TITLE
fix: update template-dns-record to v1.0.7

### DIFF
--- a/templates/template-dns-record.yaml
+++ b/templates/template-dns-record.yaml
@@ -7,7 +7,7 @@ metadata:
   name: configuration-dns-record
   namespace: crossplane-system
 spec:
-  package: ghcr.io/open-service-portal/configuration-dns-record:v1.0.6
+  package: ghcr.io/open-service-portal/configuration-dns-record:v1.0.7
 
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
## Summary
Update template-dns-record from broken v1.0.6 to working v1.0.7.

## Problem
The configuration-dns-record in the cluster is unhealthy with this error:
```
MANIFEST_UNKNOWN: manifest unknown
```

This is because v1.0.6 was never successfully pushed to ghcr.io due to a workflow issue.

## Solution
Update to v1.0.7 which contains:
- Fixed package file naming (configuration-dns-record.xpkg)
- Fixed registry path (configuration-dns-record)
- Successfully built and pushed to ghcr.io

## Verification
```bash
# v1.0.6 doesn't exist (404)
curl -I https://ghcr.io/v2/open-service-portal/configuration-dns-record/manifests/v1.0.6

# v1.0.7 exists (200)
curl -I https://ghcr.io/v2/open-service-portal/configuration-dns-record/manifests/v1.0.7
```

## Impact
Once merged and reconciled by Flux, the configuration-dns-record will become healthy in the cluster.