### PR TITLE
feat: update WhoAmI templates to v1.0.4

### DIFF
--- a/templates/template-whoami-service.yaml
+++ b/templates/template-whoami-service.yaml
@@ -13,7 +13,7 @@ metadata:
     meta.crossplane.io/source: "github.com/open-service-portal/template-whoami-service"
     meta.crossplane.io/depends-on: "configuration-whoami,configuration-cloudflare-dnsrecord"
 spec:
-  package: ghcr.io/open-service-portal/configuration-whoami-service:v1.0.3
+  package: ghcr.io/open-service-portal/configuration-whoami-service:v1.0.4
   
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)

--- a/templates/template-whoami.yaml
+++ b/templates/template-whoami.yaml
@@ -12,7 +12,7 @@ metadata:
     meta.crossplane.io/maintainer: "Open Service Portal Team"
     meta.crossplane.io/source: "github.com/open-service-portal/template-whoami"
 spec:
-  package: ghcr.io/open-service-portal/configuration-whoami:v1.0.3
+  package: ghcr.io/open-service-portal/configuration-whoami:v1.0.4
   
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
## Summary

This PR updates the WhoAmI templates to their latest v1.0.4 releases, incorporating important Crossplane v2 compatibility fixes and API simplifications.

## Changes

- **template-whoami**: v1.0.3 → v1.0.4
  - Fixed XRD composition naming for Crossplane v2 compatibility
  - Corrected namespace handling in compositions
  
- **template-whoami-service**: v1.0.3 → v1.0.4  
  - Simplified API by removing optional fields (replicas, image, proxied, ttl)
  - Fixed CloudflareDNSRecord API version references
  - Corrected status updates for composition-of-compositions pattern

## Testing

Both templates have been tested in the cluster with successful:
- XR creation and reconciliation
- DNS record provisioning via External-DNS
- Composition-of-compositions functionality

## Related

- Fixes issues discovered in open-service-portal/portal-workspace#79
- Templates released via automated release process