### PR TITLE
fix: resolve GitHub App token revocation in reusable workflow

### DIFF
--- a/.github/workflows/update-catalog-entry.yaml
+++ b/.github/workflows/update-catalog-entry.yaml
@@ -37,7 +37,6 @@ jobs:
     outputs:
       package-exists: ${{ steps.check-package.outputs.exists }}
       action: ${{ steps.check-package.outputs.action }}
-      app-token: ${{ steps.app-token.outputs.token }}
       app-slug: ${{ steps.app-token.outputs.app-slug }}
       user-id: ${{ steps.get-user-id.outputs.user-id }}
     
@@ -66,10 +65,15 @@ jobs:
 
       - name: Check if package exists in catalog
         id: check-package
+        env:
+          CATALOG_FILE: templates/${{ inputs.package-name }}.yaml
         run: |
-          CATALOG_FILE="templates/${{ inputs.package-name }}.yaml"
+          echo "📁 Current directory: $(pwd)"
+          echo "📋 Looking for: ${CATALOG_FILE}"
+          ls -la templates/ || echo "Templates directory not found"
+          
           if [ -f "${CATALOG_FILE}" ]; then
-            echo "✅ Package already exists in catalog"
+            echo "✅ Package already exists in catalog: ${CATALOG_FILE}"
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "action=update" >> "$GITHUB_OUTPUT"
           else
@@ -96,10 +100,20 @@ jobs:
       skip: ${{ steps.commit.outputs.skip }}
     
     steps:
+      # Generate NEW token for this job
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_CATALOG_CLIENT_ID }}
+          private-key: ${{ secrets.APP_CATALOG_PRIVATE_KEY }}
+          owner: open-service-portal
+          repositories: catalog
+      
       - name: Checkout Catalog Repository
         uses: actions/checkout@v4
         with:
-          token: ${{ needs.prepare.outputs.app-token }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Configure Git
@@ -116,8 +130,9 @@ jobs:
 
       - name: Generate catalog entry
         id: catalog-entry
+        env:
+          CATALOG_FILE: templates/${{ inputs.package-name }}.yaml
         run: |
-          CATALOG_FILE="templates/${{ inputs.package-name }}.yaml"
           
           # Create catalog entry content
           cat > "${CATALOG_FILE}" <<EOF
@@ -240,10 +255,20 @@ jobs:
       pr-number: ${{ steps.create-pr.outputs.pr-number }}
     
     steps:
+      # Generate NEW token for this job
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_CATALOG_CLIENT_ID }}
+          private-key: ${{ secrets.APP_CATALOG_PRIVATE_KEY }}
+          owner: open-service-portal
+          repositories: catalog
+      
       - name: Checkout Catalog Repository
         uses: actions/checkout@v4
         with:
-          token: ${{ needs.prepare.outputs.app-token }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ needs.update-catalog.outputs.branch }}
 
       - name: Create Pull Request
@@ -274,4 +299,4 @@ jobs:
           
           echo "✅ Created PR: ${PR_URL}"
         env:
-          GH_TOKEN: ${{ needs.prepare.outputs.app-token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Fixes authentication issues in the update-catalog-entry workflow where GitHub App tokens were being revoked between jobs.

## The Problem

- GitHub Actions blocks secrets from being passed as job outputs
- Tokens generated in one job are revoked after that job completes
- This caused authentication failures in subsequent jobs

## The Solution

- Each job now generates its own GitHub App token
- Removed token from job outputs
- Added debugging output for better troubleshooting
- Used `env` attribute for cleaner variable management

## Changes

- Generate token in `update-catalog` job for checkout and git operations
- Generate token in `create-pr` job for PR creation
- Add debug output to show current directory and files being checked
- Use `CATALOG_FILE` as environment variable instead of inline

## Testing

After merge, the workflow will properly authenticate in all jobs when called from template repositories.

---
*This fixes the token revocation issue discovered during workflow testing.*