### PR TITLE
fix: specify catalog repository in checkout actions

### DIFF
--- a/.github/workflows/update-catalog-entry.yaml
+++ b/.github/workflows/update-catalog-entry.yaml
@@ -58,8 +58,9 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout Catalog Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
+          repository: open-service-portal/catalog
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
@@ -111,8 +112,9 @@ jobs:
           repositories: catalog
       
       - name: Checkout Catalog Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
+          repository: open-service-portal/catalog
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
@@ -266,8 +268,9 @@ jobs:
           repositories: catalog
       
       - name: Checkout Catalog Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
+          repository: open-service-portal/catalog
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ needs.update-catalog.outputs.branch }}
 


### PR DESCRIPTION
## Summary

Fixes checkout context issues in the reusable workflow.

## Changes

- Add `repository: open-service-portal/catalog` to all checkout steps
- Update checkout action from v4 to v5 for latest features

## Why

When called as a reusable workflow, checkout defaults to the calling repository, not the catalog repository. This fix ensures the workflow always operates on the catalog repository.

## Impact

The workflow will now correctly checkout the catalog repository when called from template repositories.