### PR TITLE
feat: update WhoAmIService template to v2.0.0

### DIFF
--- a/templates/template-whoami-service.yaml
+++ b/templates/template-whoami-service.yaml
@@ -13,7 +13,7 @@ metadata:
     meta.crossplane.io/source: "github.com/open-service-portal/template-whoami-service"
     meta.crossplane.io/depends-on: "configuration-whoami,configuration-cloudflare-dnsrecord"
 spec:
-  package: ghcr.io/open-service-portal/configuration-whoami-service:v1.0.4
+  package: ghcr.io/open-service-portal/configuration-whoami-service:v2.0.0
   
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
## Summary

This PR updates the WhoAmIService template to v2.0.0, which includes significant simplifications and improvements.

## Changes

- **Template version**: v1.0.4 → v2.0.0

## What's New in v2.0.0

### Breaking Changes (Major Version)
- **Simplified API**: Now requires only the `name` field
- **Removed optional fields**: `replicas`, `image`, `proxied`, `ttl`, and `zone` are now fixed
- **Fixed defaults**:
  - Replicas: 1
  - Image: traefik/whoami:v1.10.1
  - Proxied: false
  - TTL: 1 (minimum for Cloudflare)

### Improvements
- Better Crossplane v2 compatibility
- Cleaner composition-of-compositions pattern
- Simplified user experience - just provide a name!

## Example Usage

```yaml
apiVersion: openportal.dev/v1alpha1
kind: WhoAmIService
metadata:
  name: my-app
  namespace: my-namespace
spec:
  name: my-app  # Only field required!
```

## Testing

- Template has been tested in both local and OpenPortal clusters
- DNS record creation verified via External-DNS
- Application deployment successful

## Related

- Template release: https://github.com/open-service-portal/template-whoami-service/releases/tag/v2.0.0
- Follows simplification discussed in open-service-portal/portal-workspace#79