### PR TITLE
feat: update whoami-service to v2.0.0

### DIFF
--- a/templates/template-whoami-service.yaml
+++ b/templates/template-whoami-service.yaml
@@ -13,7 +13,7 @@ metadata:
     meta.crossplane.io/source: "github.com/open-service-portal/template-whoami-service"
     meta.crossplane.io/depends-on: "configuration-whoami,configuration-cloudflare-dnsrecord"
 spec:
-  package: ghcr.io/open-service-portal/configuration-whoami-service:v1.0.4
+  package: ghcr.io/open-service-portal/configuration-whoami-service:v2.0.0
   
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
## Summary

Updates the WhoAmI Service configuration package to v2.0.0.

## Breaking Changes

**Simplified API - now requires only name field**
- Removed optional fields: `image`, `replicas`, `proxied`, `ttl`, `zone`
- Fixed values: 1 replica, traefik/whoami:v1.10.1 image  
- Composition handles all configuration internally

## Release

- Release: https://github.com/open-service-portal/template-whoami-service/releases/tag/v2.0.0
- Package: `ghcr.io/open-service-portal/configuration-whoami-service:v2.0.0`

## Impact

After merging and reconciliation, templates will show only the `name` field in Backstage UI, making the service much simpler to deploy.