### PR TITLE
feat: update template-namespace to v2.1.0 with namespaced scope

### DIFF
--- a/templates/template-namespace.yaml
+++ b/templates/template-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
   name: configuration-namespace
   namespace: crossplane-system
 spec:
-  package: ghcr.io/open-service-portal/configuration-namespace:v2.0.2
+  package: ghcr.io/open-service-portal/configuration-namespace:v2.1.0
 
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
## Summary

Updates the ManagedNamespace template to v2.1.0 with significant architectural changes to fix Flux reconciliation issues.

## Changes in v2.1.0

### Breaking Changes
- **Scope changed**: From cluster-scoped to namespaced
- **XRs location**: Now created in 'system' namespace (not cluster-wide)
- **Composition name**: Simplified from full domain to just 'managednamespaces'

### Improvements
- Added `defaultCompositionRef` for Crossplane v2 compatibility
- Fixes Flux server-side apply issues with API server cache
- Aligns with Kubernetes best practices for system resources

## Problem Solved

The OpenPortal cluster's API server was incorrectly reporting ManagedNamespace as namespaced despite the XRD being cluster-scoped. This caused Flux's server-side apply to fail with "namespace not specified" errors. By making the XRD actually namespaced (in the system namespace), we align with what the API server expects.

## Migration Required

Existing ManagedNamespace XRs need to be:
1. Deleted from cluster-scoped location
2. Recreated in the 'system' namespace

## Testing

- Template v2.1.0 released and tested
- GitHub Actions successful
- Requires system namespace to be created first

## Related PRs

- open-service-portal/portal-workspace#86 - Creates system namespace
- Updates to catalog-orders for XR placement