### PR TITLE
feat: update templates to latest versions (Sept 5)

### DIFF
--- a/templates/template-namespace.yaml
+++ b/templates/template-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
   name: configuration-namespace
   namespace: crossplane-system
 spec:
-  package: ghcr.io/open-service-portal/configuration-namespace:v2.1.0
+  package: ghcr.io/open-service-portal/configuration-namespace:v2.2.0
 
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)

--- a/templates/template-whoami-service.yaml
+++ b/templates/template-whoami-service.yaml
@@ -13,7 +13,7 @@ metadata:
     meta.crossplane.io/source: "github.com/open-service-portal/template-whoami-service"
     meta.crossplane.io/depends-on: "configuration-whoami,configuration-cloudflare-dnsrecord"
 spec:
-  package: ghcr.io/open-service-portal/configuration-whoami-service:v2.0.0
+  package: ghcr.io/open-service-portal/configuration-whoami-service:v2.0.1
   
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
## Summary

Updates Crossplane templates to their latest versions with important fixes and enhancements.

## Template Updates

### template-namespace: v2.1.0 → v2.2.0
**What's New**: Enforces system namespace for all ManagedNamespace XRs
- Adds publishPhase annotations for Backstage integration
- Sets fixedNamespace: system to prevent misconfiguration
- Ensures consistent Git path structure (system/ManagedNamespace/)
- **Impact**: Prevents namespace sprawl and maintains consistency

### template-whoami-service: v2.0.0 → v2.0.1
**What's Fixed**: DNS records now use correct ingress controller IP
- Uses environment config to get actual load balancer IP
- Fixes issue where DNS records had placeholder IPs
- **Impact**: DNS records will work correctly out of the box

## Testing

Both templates have been tested in the cluster:
- ManagedNamespace XRs are working in system namespace
- WhoAmIService creates both app and DNS components successfully
- GitOps with Flux confirmed working

## Deployment

After merge, Flux will automatically:
1. Pull the new template versions
2. Update the installed configurations
3. New XRs will use the updated templates

## Related

- template-namespace PR #3: Enforcement implementation
- template-whoami-service commit: 8cf7cba