### PR TITLE
chore: update CloudflareDNSRecord template to v2.0.2

### DIFF
--- a/templates/template-cloudflare-dnsrecord.yaml
+++ b/templates/template-cloudflare-dnsrecord.yaml
@@ -1,6 +1,7 @@
 # Cloudflare DNS Record Template
 # Provides real DNS record management via External-DNS
 # Breaking Change in v2.0.0: Migrated from provider-cloudflare to External-DNS
+# Fix in v2.0.2: CloudflareDNSRecord XRs now correctly show as Ready
 # Deployed via OCI Configuration package from GitHub Container Registry
 ---
 apiVersion: pkg.crossplane.io/v1
@@ -14,7 +15,7 @@ metadata:
     meta.crossplane.io/source: "github.com/open-service-portal/template-cloudflare-dnsrecord"
     meta.crossplane.io/breaking-change: "v2.0.0 - Requires External-DNS instead of provider-cloudflare"
 spec:
-  package: ghcr.io/open-service-portal/configuration-cloudflare-dnsrecord:v2.0.1
+  package: ghcr.io/open-service-portal/configuration-cloudflare-dnsrecord:v2.0.2
   
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
## Summary
Update CloudflareDNSRecord template to v2.0.2 which fixes the readiness condition issue.

## Changes
- Bumps template version from v2.0.1 to v2.0.2
- Adds comment about the fix in v2.0.2

## What v2.0.2 Fixes
- CloudflareDNSRecord XRs now correctly show as "Ready" in Backstage
- Resolved issue where resources were perpetually showing as "not ready"
- Fixed by adding `gotemplating.fn.crossplane.io/ready: "True"` annotation to DNSEndpoint

## Testing
- Template v2.0.2 has been tested in local cluster
- No breaking changes - safe to deploy

## Related
- Template release: https://github.com/open-service-portal/template-cloudflare-dnsrecord/releases/tag/v2.0.2
