### PR TITLE
fix: update ManagedNamespace to v3.0.1 with cluster scope

### DIFF
--- a/templates/template-namespace.yaml
+++ b/templates/template-namespace.yaml
@@ -1,14 +1,14 @@
 ---
 # Namespace Configuration Package
 # Provides XRD and Composition for Kubernetes namespace management
-# BREAKING CHANGE v3.0.0: Simplified API - only namespace name required
+# v3.0.1: Fixed XRD scope to Cluster for creating Namespace resources
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
   name: configuration-namespace
   namespace: crossplane-system
 spec:
-  package: ghcr.io/open-service-portal/configuration-namespace:v3.0.0
+  package: ghcr.io/open-service-portal/configuration-namespace:v3.0.1
 
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
Updates configuration-namespace to v3.0.1 which fixes XRD scope to be Cluster instead of Namespaced, allowing creation of Namespace resources.