### PR TITLE
chore: update WhoAmI Service template to v2.0.2

### DIFF
--- a/templates/template-whoami-service.yaml
+++ b/templates/template-whoami-service.yaml
@@ -13,7 +13,7 @@ metadata:
     meta.crossplane.io/source: "github.com/open-service-portal/template-whoami-service"
     meta.crossplane.io/depends-on: "configuration-whoami,configuration-cloudflare-dnsrecord"
 spec:
-  package: ghcr.io/open-service-portal/configuration-whoami-service:v2.0.1
+  package: ghcr.io/open-service-portal/configuration-whoami-service:v2.0.2
   
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
## Summary
- Updates the WhoAmI Service Crossplane Configuration from v2.0.1 to v2.0.2
- This composite template bundles WhoAmI application with automatic DNS configuration

## Changes
- Updated package version in `templates/template-whoami-service.yaml`
- From: `ghcr.io/open-service-portal/configuration-whoami-service:v2.0.1`
- To: `ghcr.io/open-service-portal/configuration-whoami-service:v2.0.2`

## Testing
- [ ] Flux will automatically sync this change once merged
- [ ] The new version will be pulled and installed by Crossplane
- [ ] Existing WhoAmI Service instances will continue to work with their current revision

## Notes
This is a routine version update following the release of v2.0.2 of the template-whoami-service repository.