### PR TITLE
feat: register valkey template (configuration-valkey v0.1.0)

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - templates/template-cloudflare-dnsrecord.yaml
   - templates/template-whoami-service.yaml
   - templates/template-namespace.yaml
+  - templates/template-valkey.yaml

--- a/templates/template-valkey.yaml
+++ b/templates/template-valkey.yaml
@@ -1,0 +1,28 @@
+---
+# Valkey Configuration Package
+# Registry: ghcr.io/open-service-portal
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: configuration-valkey
+  namespace: crossplane-system
+spec:
+  package: ghcr.io/open-service-portal/configuration-valkey:v0.1.0
+
+  # Package pull policy
+  # IfNotPresent: Only download if not in cache (recommended for production)
+  # Always: Check for updates on reconciliation (useful for development)
+  packagePullPolicy: IfNotPresent
+
+  # Revision activation policy
+  # Automatic: New revisions become active immediately (good for single-tenant)
+  # Manual: Requires manual activation (safer for multi-tenant production)
+  revisionActivationPolicy: Automatic
+
+  # Number of inactive revisions to keep
+  # Useful for rollback scenarios
+  revisionHistoryLimit: 3
+
+  # Skip dependency resolution
+  # Set to true since providers are pre-installed in the cluster
+  skipDependencyResolution: true


### PR DESCRIPTION
Registers the Valkey Configuration package so Flux deploys it and the `ValkeyInstance` template becomes available in clusters.

- `templates/template-valkey.yaml` → `ghcr.io/open-service-portal/configuration-valkey:v0.1.0`
- added to `kustomization.yaml`

Source: open-service-portal/template-valkey (released v0.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)