### PR TITLE
chore: bump configuration-valkey to v0.2.0 (adds web UI)

### DIFF
--- a/templates/template-valkey.yaml
+++ b/templates/template-valkey.yaml
@@ -7,7 +7,7 @@ metadata:
   name: configuration-valkey
   namespace: crossplane-system
 spec:
-  package: ghcr.io/open-service-portal/configuration-valkey:v0.1.0
+  package: ghcr.io/open-service-portal/configuration-valkey:v0.2.0
 
   # Package pull policy
   # IfNotPresent: Only download if not in cache (recommended for production)


### PR DESCRIPTION
## What

Bump the `configuration-valkey` package pin from `v0.1.0` to `v0.2.0`.

## Why

`v0.2.0` (released from `template-valkey` main) adds the per-instance Valkey Admin web UI (#9/#10): the composition now also renders a `valkey-admin` Deployment/Service per `ValkeyInstance`, gated on `spec.observability.webUI` (default true), using `valkey/valkey-admin:edge`. `v0.1.0` had no web UI.

Flux reconciles this entry, so merging updates the installed Configuration on the cluster to `v0.2.0`.

## Verification

- `ghcr.io/open-service-portal/configuration-valkey:v0.2.0` was published by the template-valkey release workflow (run for tag v0.2.0, success).
- After merge, Flux updates the `configuration-valkey` Configuration; a new `ValkeyInstance` order then also provisions the admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
