### PR TITLE
feat: register configuration-exposed-service (v0.1.0) in catalog

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - templates/template-whoami-service.yaml
   - templates/template-namespace.yaml
   - templates/template-valkey.yaml
+  - templates/template-exposed-service.yaml

--- a/templates/template-exposed-service.yaml
+++ b/templates/template-exposed-service.yaml
@@ -1,0 +1,15 @@
+---
+# ExposedService Configuration Package
+# Registry: ghcr.io/open-service-portal
+# Publishes an in-cluster Service over HTTPS via Gateway API (HTTPRoute); TLS + DNS via platform.
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: configuration-exposed-service
+  namespace: crossplane-system
+spec:
+  package: ghcr.io/open-service-portal/configuration-exposed-service:v0.1.0
+  packagePullPolicy: IfNotPresent
+  revisionActivationPolicy: Automatic
+  revisionHistoryLimit: 3
+  skipDependencyResolution: true


### PR DESCRIPTION
## What

Register the `configuration-exposed-service` package (v0.1.0) in the catalog so Flux installs it on the cluster.

## Why

`configuration-exposed-service` provides the `ExposedService` XRD + composition (Gateway API HTTPRoute; TLS + DNS via the platform). It was released from `template-exposed-service` (v0.1.0, `ghcr.io/open-service-portal/configuration-exposed-service:v0.1.0`). Adding it here lets Flux install it alongside the other Configuration packages, so `ExposedService` resources can be created on the cluster.

## Verification

- `ghcr.io/open-service-portal/configuration-exposed-service:v0.1.0` is published (template-exposed-service release workflow, success).
- After merge, Flux applies the entry; the `exposedservices.openportal.dev` XRD becomes available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
